### PR TITLE
Add SU check on start

### DIFF
--- a/src/com/ota/updates/activities/MainActivity.java
+++ b/src/com/ota/updates/activities/MainActivity.java
@@ -58,6 +58,9 @@ import com.ota.updates.utils.Constants;
 import com.ota.updates.utils.Preferences;
 import com.ota.updates.utils.Utils;
 
+import java.io.IOException;
+import java.lang.Process;
+
 public class MainActivity extends Activity implements Constants{
 
 	public final String TAG = this.getClass().getSimpleName();
@@ -128,6 +131,14 @@ public class MainActivity extends Activity implements Constants{
 		if(!oldChangelog.equals(currentChangelog)) {
 			showWhatsNew();
 		}
+		
+		//Ask for SU, we'll need it later!!
+		try {
+		  Process p = Runtime.getRuntime().exec("su");
+		} catch (IOException e) {
+		  Log.d(TAG, e.getMessage());	
+		}
+		
 		
 		// Create download directories if needed
 		File installAfterFlashDir = new File(SD_CARD 


### PR DESCRIPTION
When OTA installation is triggered, it generates and executes an ORS to start.
When rebooting, the app asks for su before execution. Sometimes the app executes the reboot without getting su permission. This asks for su on the MainActivity.
